### PR TITLE
Improve timer logic

### DIFF
--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -1,11 +1,10 @@
 import { useState, useEffect, useRef } from 'react'
 
 export function useTimer(initialMinutes = 25, breakMinutes = 5) {
-  const [minutes, setMinutes] = useState(initialMinutes)
-  const [seconds, setSeconds] = useState(0)
+  const [timeLeft, setTimeLeft] = useState(initialMinutes * 60)
   const [isRunning, setIsRunning] = useState(false)
   const [onBreak, setOnBreak] = useState(false)
-  const timerRef = useRef<NodeJS.Timeout | null>(null)
+  const timerRef = useRef<number | null>(null)
 
   function start() {
     if (!isRunning) setIsRunning(true)
@@ -17,35 +16,31 @@ export function useTimer(initialMinutes = 25, breakMinutes = 5) {
 
   function reset() {
     pause()
-    setMinutes(initialMinutes)
-    setSeconds(0)
     setOnBreak(false)
+    setTimeLeft(initialMinutes * 60)
   }
 
   useEffect(() => {
-    if (isRunning) {
-      timerRef.current = setInterval(() => {
-        setSeconds((sec) => {
-          if (sec === 0) {
-            setMinutes((min) => {
-              if (min === 0) {
-                // switch mode
-                const newOnBreak = !onBreak
-                setOnBreak(newOnBreak)
-                return newOnBreak ? breakMinutes : initialMinutes
-              }
-              return min - 1
-            })
-            return 59
-          }
-          return sec - 1
-        })
-      }, 1000)
-    }
+    if (!isRunning) return
+
+    timerRef.current = setInterval(() => {
+      setTimeLeft((t) => {
+        if (t === 0) {
+          const nextOnBreak = !onBreak
+          setOnBreak(nextOnBreak)
+          return (nextOnBreak ? breakMinutes : initialMinutes) * 60
+        }
+        return t - 1
+      })
+    }, 1000)
+
     return () => {
       if (timerRef.current) clearInterval(timerRef.current)
     }
   }, [isRunning, onBreak, initialMinutes, breakMinutes])
+
+  const minutes = Math.floor(timeLeft / 60)
+  const seconds = timeLeft % 60
 
   return { minutes, seconds, isRunning, onBreak, start, pause, reset }
 }

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -1,7 +1,9 @@
-import dayjs from 'dayjs'
+function formatDate() {
+  return new Date().toISOString().slice(0, 10)
+}
 
 export function generateMarkdown(sessions: any[]) {
-  const date = dayjs().format('YYYY-MM-DD')
+  const date = formatDate()
   const lines = [`## ${date}`]
   sessions.forEach((s) => {
     const status = s.status === 'complete' ? '[x]' : '[ ]'
@@ -13,7 +15,7 @@ export function generateMarkdown(sessions: any[]) {
 
 export function generateJSON(sessions: any[]) {
   return JSON.stringify({
-    date: dayjs().format('YYYY-MM-DD'),
-    sessions
+    date: formatDate(),
+    sessions,
   }, null, 2)
 }


### PR DESCRIPTION
## Summary
- refactor `useTimer` to track time in seconds and fix reset behavior
- drop dayjs in utils and use a simple date helper

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_685498e361bc83228baef20814b5aa58